### PR TITLE
Removed theme installer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": "^7.3",
-        "aldrumo/theme-installer": "~2.0",
         "illuminate/support": "^8.0",
         "aldrumo/support": "^0.1"
     },


### PR DESCRIPTION
Part of Aldrumo/core#1

No need for composer based themes to go into Themes folder. It ends up getting ignored and it should be reserved for Manual themes.